### PR TITLE
feat: update GitHub Actions workflow to trigger deployment on closed pull requests and add versioning steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,11 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches: [main]
-  workflow_dispatch:
+    paths-ignore:
+     - '.github/workflows/**'
 
 # Allow this job to clone the repo and create a page deployment
 permissions:
@@ -12,8 +14,44 @@ permissions:
   id-token: write
 
 jobs:
+  create-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get label
+        uses: actions-ecosystem/action-release-label@v1
+        id: release-label
+        if: ${{ github.event.pull_request.merged == true }}
+        with:
+          label_prefix: ''
+
+      - name: Get latest tag
+        id: get-latest-tag
+        uses: actions-ecosystem/action-get-latest-tag@v1
+        if: ${{ steps.release-label.outputs.level != null }}
+
+      - name: Update package.json and Push tag
+        id: auto-version-sync
+        uses: bryanus1/auto-version-sync@v1.1.1
+        if: ${{ steps.release-label.outputs.level != null }}
+        with:
+          git_username: ${{ github.actor }}
+          git_email: ${{ github.actor }}@users.noreply.github.com
+          level: ${{ steps.release-label.outputs.level }}
+          current_version: ${{ steps.get-latest-tag.outputs.tag }}
+
+      - name: Validate version
+        run: |
+          echo "Validating version"
+          if [ -z "${{ steps.auto-version-sync.outputs.new_version }}" ]; then
+            echo "No new version found"
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
+    needs: create-version
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request introduces changes to the GitHub Actions workflow for deploying to GitHub Pages. The main adjustments include triggering the workflow on pull request closures instead of pushes, adding a new job to handle versioning, and updating the build job dependencies.

Changes to workflow triggers and paths:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L4-R8): Changed the trigger from `push` to `pull_request` with `types: [closed]` and added `paths-ignore` to exclude changes in the workflow files themselves from triggering the workflow.

Addition of versioning job:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R17-R54): Added a new job named `create-version` that runs on `ubuntu-latest`. This job includes steps to checkout the repository, get the release label, fetch the latest tag, update the `package.json` version, push the new tag, and validate the new version.

Dependencies update in build job:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R17-R54): Updated the `build` job to depend on the `create-version` job, ensuring versioning is handled before the build process.