### PR TITLE
feat: update GitHub Actions workflow to allow write permissions and upgrade checkout action to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
 
 # Allow this job to clone the repo and create a page deployment
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -17,7 +17,10 @@ jobs:
   create-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get label
         uses: actions-ecosystem/action-release-label@v1


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration to update permissions and improve the checkout step.

Improvements to GitHub Actions workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L12-R23): Changed `contents` permission from `read` to `write` to allow the job to create a page deployment.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L12-R23): Updated the `actions/checkout` step from version 2 to version 4 and added a token input to use the GitHub token secret.