### PR TITLE
fix: update git_email in deploy workflow to use secrets for better security

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,8 +36,8 @@ jobs:
         uses: bryanus1/auto-version-sync@v1.1.1
         if: ${{ steps.release-label.outputs.level != null }}
         with:
+          git_email: ${{ secrets.EMAIL }}
           git_username: ${{ github.actor }}
-          git_email: ${{ github.actor }}@users.noreply.github.com
           level: ${{ steps.release-label.outputs.level }}
           current_version: ${{ steps.get-latest-tag.outputs.tag }}
 

--- a/src/components/about-me.astro
+++ b/src/components/about-me.astro
@@ -76,7 +76,7 @@ cutting-edge solutions for my clients.
               y2="18"></line></svg
           >
           <h3 class="text-xl font-semibold mt-4 mb-2">Backend</h3>
-          <p class="text-gray-600">Node.js, Express, Fastify</p>
+          <p class="text-gray-600">Node.js, Express</p>
         </div>
 
         <div class="bg-white p-6 rounded-lg shadow-md">


### PR DESCRIPTION
This pull request includes updates to the deployment workflow and a minor content change in the `about-me` component. The most important changes are:

Deployment Workflow Updates:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R39-L40): Updated the `git_email` configuration to use a secret value instead of the GitHub actor's noreply email.

Content Update:
* [`src/components/about-me.astro`](diffhunk://#diff-6b77be428ad95f5b767395da6af09c0015a02a9486049b070579409ff87705bcL79-R79): Removed `Fastify` from the list of backend technologies.