### PR TITLE
refactor: simplify deploy workflow by removing unused versioning steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,44 +14,8 @@ permissions:
   id-token: write
 
 jobs:
-  create-version:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Get label
-        uses: actions-ecosystem/action-release-label@v1
-        id: release-label
-        if: ${{ github.event.pull_request.merged == true }}
-        with:
-          label_prefix: ''
-
-      - name: Get latest tag
-        id: get-latest-tag
-        uses: actions-ecosystem/action-get-latest-tag@v1
-        if: ${{ steps.release-label.outputs.level != null }}
-
-      - name: Update package.json and Push tag
-        id: auto-version-sync
-        uses: bryanus1/auto-version-sync@v1.1.1
-        if: ${{ steps.release-label.outputs.level != null }}
-        with:
-          git_email: ${{ secrets.EMAIL }}
-          git_username: ${{ github.actor }}
-          level: ${{ steps.release-label.outputs.level }}
-          current_version: ${{ steps.get-latest-tag.outputs.tag }}
-
-      - name: Validate version
-        run: |
-          echo "Validating version"
-          if [ -z "${{ steps.auto-version-sync.outputs.new_version }}" ]; then
-            echo "No new version found"
-            exit 1
-          fi
-
   build:
     runs-on: ubuntu-latest
-    needs: create-version
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4

--- a/src/components/about-me.astro
+++ b/src/components/about-me.astro
@@ -96,7 +96,7 @@ cutting-edge solutions for my clients.
               d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg
           >
           <h3 class="text-xl font-semibold mt-4 mb-2">Database</h3>
-          <p class="text-gray-600">MongoDB, Mongoose</p>
+          <p class="text-gray-600">MongoDB</p>
         </div>
 
         <div class="bg-white p-6 rounded-lg shadow-md">


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow and a minor update to the `about-me.astro` component. The most important changes are:

### GitHub Actions Workflow:

* Removed the `create-version` job from the `.github/workflows/deploy.yml` file, which included steps for checking out the repository, getting the release label, getting the latest tag, updating `package.json`, and validating the version.

### Component Update:

* Updated the `src/components/about-me.astro` file to remove `Mongoose` from the list of database technologies, leaving only `MongoDB`.